### PR TITLE
ci: Skip pushing images to the registry from PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.latest-snapshots
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
Pushing Docker images to the registry from a PR coming from another repository would fail with:

    ------
     > pushing ghcr.io/collabora/aptly-rest-tools:pr-21 with docker:
    ------
    ERROR: denied: installation not allowed to Write organization package

Avoid the actual push so people can submit PRs from their forks.