### PR TITLE
ci: Add the :latest tag to Docker images on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v4
         with:
+          tags: |
+            # explicitly set the default behavior, so we can
+            # customize things later
+            # see https://github.com/docker/metadata-action#tags-input
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
           images: |
             # this one is just for backward compatibility (April 2025)
             ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,10 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           tags: |
-            # explicitly set the default behavior, so we can
-            # customize things later
+            # set latest tag for default branch
+            # see https://github.com/docker/metadata-action#latest-tag
+            type=raw,value=latest,enable={{is_default_branch}}
+            # then follow the default behavior
             # see https://github.com/docker/metadata-action#tags-input
             type=schedule
             type=ref,event=branch

--- a/Dockerfile.latest-snapshots
+++ b/Dockerfile.latest-snapshots
@@ -1,11 +1,13 @@
 FROM rust:1.71.0-slim-bookworm AS build
 ARG DEBIAN_FRONTEND=noninteractive
 
-ADD . /app
-WORKDIR /app
 RUN apt-get update \
   && apt-get install -y pkg-config libssl-dev \
-  && cargo build -p aptly-latest-snapshots --release
+  && rm -rf /var/lib/apt/lists/
+
+WORKDIR /src
+RUN --mount=type=bind,source=.,target=/src \
+  cargo build -p aptly-latest-snapshots --release --target-dir /app
 
 FROM debian:bookworm-slim
 ARG DEBIAN_FRONTEND=noninteractive
@@ -13,6 +15,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
   && apt-get install -y libssl3 ca-certificates \
   && rm -rf /var/lib/apt/lists/
-COPY --from=build /app/target/release/aptly-latest-snapshots /usr/local/bin/
+COPY --from=build /app/release/aptly-latest-snapshots /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/aptly-latest-snapshots"]


### PR DESCRIPTION
At the moment we only push tags matching the branch name, that is the `main` tag for the `main` branch.

Follow the advice from the https://github.com/docker/metadata-action documentation to generate the conventional `latest` tag when changes are landed to the main branch: https://github.com/docker/metadata-action#latest-tag

Test runs:

* non-default branch: https://github.com/emanueleaina/aptly-rest-tools/actions/runs/14367691832/job/40284539981#step:5:1036

        #17 pushing ghcr.io/emanueleaina/aptly-rest-tools:wip-em-ci-docker-latest-tag with docker
        …
        #18 pushing ghcr.io/emanueleaina/aptly-rest-tools/latest-snapshots:wip-em-ci-docker-latest-tag with docker

* default branch: https://github.com/emanueleaina/aptly-rest-tools/actions/runs/14367694375/job/40284550878#step:5:1041

        #17 pushing ghcr.io/emanueleaina/aptly-rest-tools:main with docker
        …
        #18 pushing ghcr.io/emanueleaina/aptly-rest-tools:latest with docker
        …
        #19 pushing ghcr.io/emanueleaina/aptly-rest-tools/latest-snapshots:main with docker
        …
        #20 pushing ghcr.io/emanueleaina/aptly-rest-tools/latest-snapshots:latest with docker
        …
