### PR TITLE
ci: Add a unique tag to Docker images for each worflow run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
             # set latest tag for default branch
             # see https://github.com/docker/metadata-action#latest-tag
             type=raw,value=latest,enable={{is_default_branch}}
+            # add a unique tag for each workflow run
+            type=raw,value=raw,ci-${{ github.run_id }}
             # then follow the default behavior
             # see https://github.com/docker/metadata-action#tags-input
             type=schedule


### PR DESCRIPTION
This allows people to reference a specific image.

The workflow ID ensures that the tag is sufficiently unique, unlike using the commit SHA or other identifiers that may cause tags to be overridden when triggering multiple workflows on the same commit for any reason.