### PR TITLE
docker: Add cli image with all the utilities (apt2aptly, aptlyctl, etc.)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,11 @@ jobs:
       contents: read
       packages: write
 
-    env:
-      IMAGE_NAME: latest-snapshots
+    strategy:
+      matrix:
+        include:
+          - IMAGE_NAME: latest-snapshots
+          - IMAGE_NAME: cli
 
     steps:
       - uses: actions/checkout@v3
@@ -82,14 +85,14 @@ jobs:
             type=ref,event=pr
           images: |
             # this one is just for backward compatibility (April 2025)
-            ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}
+            name=${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }},enable=${{ matrix.IMAGE_NAME == 'latest-snapshots' }}
             # use this one
-            ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.IMAGE_NAME }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: Dockerfile.${{ env.IMAGE_NAME }}
+          file: Dockerfile.${{ matrix.IMAGE_NAME }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,0 +1,18 @@
+FROM rust:1.87.0-slim-bookworm AS build
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y pkg-config libssl-dev \
+  && rm -rf /var/lib/apt/lists/
+
+WORKDIR /src
+RUN --mount=type=bind,source=.,target=/src \
+  cargo build -p apt2aptly -p aptlyctl -p obs2aptly --bins --release --target-dir /app
+
+FROM debian:bookworm-slim
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y libssl3 ca-certificates \
+  && rm -rf /var/lib/apt/lists/
+COPY --from=build /app/release/apt2aptly /app/release/aptlyctl /app/release/obs2aptly /usr/local/bin/


### PR DESCRIPTION
Even though they are single binaries, shipping all of them in a container image can be useful for a few usecases:

1. using them from Kubernetes jobs
2. using them with `COPY --from=` in `Dockerfiles`
3. enabling people to run them without setting up a Rust toolchain