### PR TITLE
obs2aptly: Add a flag '--only' to filter file types

### DIFF
--- a/obs2aptly/tests/sync.rs
+++ b/obs2aptly/tests/sync.rs
@@ -171,6 +171,10 @@ async fn run_test<P: AsRef<Path>>(path: P, repo: &str) {
         aptly.clone(),
         aptly_contents,
         PoolPackagesCache::new(aptly.clone()),
+        &obs2aptly::ScanOptions {
+            include_binaries: true,
+            include_sources: true,
+        },
     )
     .await
     .unwrap();


### PR DESCRIPTION
`--only=binaries` will only sync binaries, and similarly `--only=sources` does sources. (We only need the former of these, but it felt weird to add this in an overly one-sided way.)