### PR TITLE
Add YAML output format support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         with:
             components: clippy
             # Pin clippy, so that new lints don't break the build.
-            toolchain: '1.87.0'
+            toolchain: '1.88.0'
       - run: cargo clippy --all-targets -- -D warnings
 
   docker-image:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "color-eyre",
  "http 1.3.1",
  "serde_json",
+ "serde_yaml",
  "tokio",
  "tracing",
  "tracing-error",
@@ -3962,6 +3963,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.9.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4598,6 +4612,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -107,6 +108,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -256,6 +268,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "http 1.3.1",
+ "serde-saphyr",
  "serde_json",
  "tokio",
  "tracing",
@@ -282,6 +295,12 @@ dependencies = [
  "password-hash",
  "zeroize",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "assert-json-diff"
@@ -1511,6 +1530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1849,16 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -2562,7 +2600,7 @@ checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
  "cfg-if",
  "miette-derive",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2634,6 +2672,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3873,6 +3917,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "getrandom 0.3.3",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4581,6 +4644,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -5308,6 +5377,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM rust:1.87.0-slim-bookworm AS build
+FROM rust:1.88.0-slim-bookworm AS build
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \

--- a/Dockerfile.latest-snapshots
+++ b/Dockerfile.latest-snapshots
@@ -1,4 +1,4 @@
-FROM rust:1.87.0-slim-bookworm AS build
+FROM rust:1.88.0-slim-bookworm AS build
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \

--- a/aptly-rest-mock/src/lib.rs
+++ b/aptly-rest-mock/src/lib.rs
@@ -115,7 +115,7 @@ impl AptlyRestMock {
     /// and the repository should be part of the repositories
     pub fn repo_add_package(&self, repo: &str, key: String) {
         let mut inner = self.inner.write().unwrap();
-        assert!(inner.pool.has_package(&key), "{} not found in pool", key);
+        assert!(inner.pool.has_package(&key), "{key} not found in pool");
         inner.repositories.add_package(repo, key);
     }
 

--- a/aptly-rest/tests/control_parsing.rs
+++ b/aptly-rest/tests/control_parsing.rs
@@ -45,7 +45,7 @@ async fn test_dsc<P: AsRef<Path>>(file: P) {
 
     let dsc = Dsc::from_file(path).await.unwrap();
     let key = AptlyKey::try_from(&dsc).unwrap();
-    assert_eq!(key, expected, "Got: {} Expected: {}", key, expected);
+    assert_eq!(key, expected, "Got: {key} Expected: {expected}");
 }
 
 #[tokio::test]
@@ -109,9 +109,7 @@ async fn scanner() {
     ] {
         assert!(
             found.iter().any(|s| s.as_str() == item),
-            "{} not in {:#?}",
-            item,
-            found
+            "{item} not in {found:#?}"
         );
     }
 }

--- a/aptlyctl/Cargo.toml
+++ b/aptlyctl/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4", features = ["derive", "env"] }
 color-eyre = "0.6.4"
 http = "1.3.1"
 serde_json = "1.0.140"
+serde_yaml = "0.9"
 tokio = { version = "1.45.1", features = ["full"] }
 tracing = "0.1.41"
 tracing-error = "0.2.1"

--- a/aptlyctl/Cargo.toml
+++ b/aptlyctl/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4", features = ["derive", "env"] }
 color-eyre = "0.6.4"
 http = "1.3.1"
 serde_json = "1.0.140"
+serde-saphyr = "0.0.27"
 tokio = { version = "1.45.1", features = ["full"] }
 tracing = "0.1.41"
 tracing-error = "0.2.1"

--- a/aptlyctl/src/main.rs
+++ b/aptlyctl/src/main.rs
@@ -21,6 +21,7 @@ enum OutputFormat {
     #[default]
     Name,
     Json,
+    Yaml,
 }
 
 #[derive(Subcommand, Debug)]

--- a/aptlyctl/src/publish.rs
+++ b/aptlyctl/src/publish.rs
@@ -146,6 +146,9 @@ impl PublishCommand {
                         serde_json::to_writer_pretty(&mut stdout(), &publishes)?;
                         println!();
                     }
+                    OutputFormat::Yaml => {
+                        serde_yaml::to_writer(&mut stdout(), &publishes)?;
+                    }
                 }
             }
             PublishCommand::TestExists(args) => {

--- a/aptlyctl/src/publish.rs
+++ b/aptlyctl/src/publish.rs
@@ -141,7 +141,7 @@ impl PublishCommand {
                             .collect();
                         names.sort();
                         for name in names {
-                            println!("{}", name);
+                            println!("{name}");
                         }
                     }
                     OutputFormat::Json => {

--- a/aptlyctl/src/publish.rs
+++ b/aptlyctl/src/publish.rs
@@ -148,6 +148,10 @@ impl PublishCommand {
                         serde_json::to_writer_pretty(&mut stdout(), &publishes)?;
                         println!();
                     }
+                    OutputFormat::Yaml => {
+                        serde_saphyr::to_io_writer(&mut stdout(), &publishes)?;
+                        println!();
+                    }
                 }
             }
             PublishCommand::TestExists(args) => {

--- a/aptlyctl/src/repo.rs
+++ b/aptlyctl/src/repo.rs
@@ -63,7 +63,7 @@ impl RepoPackagesCommand {
 
                     keys.sort();
                     for key in keys {
-                        println!("{}", key);
+                        println!("{key}");
                     }
                 }
                 OutputFormat::Json | OutputFormat::Yaml => {
@@ -270,7 +270,7 @@ impl RepoCommand {
                         let mut names: Vec<_> = repos.iter().map(|r| r.name()).collect();
                         names.sort();
                         for name in names {
-                            println!("{}", name);
+                            println!("{name}");
                         }
                     }
                     OutputFormat::Json => {

--- a/aptlyctl/src/repo.rs
+++ b/aptlyctl/src/repo.rs
@@ -66,7 +66,7 @@ impl RepoPackagesCommand {
                         println!("{}", key);
                     }
                 }
-                OutputFormat::Json => {
+                OutputFormat::Json | OutputFormat::Yaml => {
                     let results = aptly
                         .repo(&args.repo)
                         .packages()
@@ -77,7 +77,16 @@ impl RepoPackagesCommand {
                         return Ok(ExitCode::FAILURE);
                     }
 
-                    serde_json::to_writer_pretty(&mut stdout(), &results)?;
+                    match args.format {
+                        OutputFormat::Json => {
+                            serde_json::to_writer_pretty(&mut stdout(), &results)?;
+                        }
+                        OutputFormat::Yaml => {
+                            serde_saphyr::to_io_writer(&mut stdout(), &results)?;
+                        }
+                        _ => unreachable!(),
+                    }
+                    println!();
                 }
             },
             RepoPackagesCommand::Delete(mut args) => {
@@ -266,6 +275,10 @@ impl RepoCommand {
                     }
                     OutputFormat::Json => {
                         serde_json::to_writer_pretty(&mut stdout(), &repos)?;
+                        println!();
+                    }
+                    OutputFormat::Yaml => {
+                        serde_saphyr::to_io_writer(&mut stdout(), &repos)?;
                         println!();
                     }
                 }

--- a/aptlyctl/src/repo.rs
+++ b/aptlyctl/src/repo.rs
@@ -69,6 +69,19 @@ impl RepoPackagesCommand {
 
                     serde_json::to_writer_pretty(&mut stdout(), &results)?;
                 }
+                OutputFormat::Yaml => {
+                    let results = aptly
+                        .repo(&args.repo)
+                        .packages()
+                        .query(args.query, false)
+                        .detailed()
+                        .await?;
+                    if args.fail_if_empty && results.is_empty() {
+                        return Ok(ExitCode::FAILURE);
+                    }
+
+                    serde_yaml::to_writer(&mut stdout(), &results)?;
+                }
             },
             RepoPackagesCommand::Delete(mut args) => {
                 for query in args.queries {
@@ -200,6 +213,9 @@ impl RepoCommand {
                     OutputFormat::Json => {
                         serde_json::to_writer_pretty(&mut stdout(), &repos)?;
                         println!();
+                    }
+                    OutputFormat::Yaml => {
+                        serde_yaml::to_writer(&mut stdout(), &repos)?;
                     }
                 }
             }

--- a/aptlyctl/src/snapshot.rs
+++ b/aptlyctl/src/snapshot.rs
@@ -43,7 +43,7 @@ impl SnapshotCommand {
                         let mut names: Vec<_> = snapshots.iter().map(|s| s.name()).collect();
                         names.sort();
                         for name in names {
-                            println!("{}", name);
+                            println!("{name}");
                         }
                     }
                     OutputFormat::Json => {

--- a/aptlyctl/src/snapshot.rs
+++ b/aptlyctl/src/snapshot.rs
@@ -50,6 +50,10 @@ impl SnapshotCommand {
                         serde_json::to_writer_pretty(&mut stdout(), &snapshots)?;
                         println!();
                     }
+                    OutputFormat::Yaml => {
+                        serde_saphyr::to_io_writer(&mut stdout(), &snapshots)?;
+                        println!();
+                    }
                 }
             }
 

--- a/aptlyctl/src/snapshot.rs
+++ b/aptlyctl/src/snapshot.rs
@@ -50,6 +50,9 @@ impl SnapshotCommand {
                         serde_json::to_writer_pretty(&mut stdout(), &snapshots)?;
                         println!();
                     }
+                    OutputFormat::Yaml => {
+                        serde_yaml::to_writer(&mut stdout(), &snapshots)?;
+                    }
                 }
             }
 

--- a/obs2aptly/tests/sync.rs
+++ b/obs2aptly/tests/sync.rs
@@ -100,13 +100,13 @@ fn compare_actions(
         if let Some((i, _)) = found {
             expected.swap_remove(i);
         } else {
-            eprintln!("- Unexpected action: {:?}", action);
+            eprintln!("- Unexpected action: {action:?}");
             r = Err(eyre!("Actions didn't match"));
         }
     }
 
     for action in expected {
-        eprintln!("- Missing action: {:?}", action);
+        eprintln!("- Missing action: {action:?}");
         r = Err(eyre!("Actions didn't match"));
     }
 

--- a/sync2aptly/src/lib.rs
+++ b/sync2aptly/src/lib.rs
@@ -224,7 +224,7 @@ impl Display for OriginLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             OriginLocation::Path(path) => write!(f, "{}", path.display()),
-            OriginLocation::Url(url) => write!(f, "{}", url),
+            OriginLocation::Url(url) => write!(f, "{url}"),
         }
     }
 }


### PR DESCRIPTION
YAML is useful as it’s slightly more compact and readable than JSON.

This requires a new `serde-saphyr` dependency and an update to Rust 1.88.

Fixes: #40