### PR TITLE
Add import commands for repos and publishes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "color-eyre",
  "http 1.3.1",
  "serde_json",
+ "serde_yaml",
  "tokio",
  "tracing",
  "tracing-error",
@@ -3962,6 +3963,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.9.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4598,6 +4612,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/aptly-rest/src/api/publish.rs
+++ b/aptly-rest/src/api/publish.rs
@@ -195,6 +195,8 @@ pub struct PublishedRepo {
     #[serde_as(as = "YesNoBool")]
     but_automatic_upgrades: bool,
     acquire_by_hash: bool,
+    #[serde(default)]
+    skip_contents: bool,
 }
 
 impl PublishedRepo {
@@ -240,6 +242,10 @@ impl PublishedRepo {
 
     pub fn acquire_by_hash(&self) -> bool {
         self.acquire_by_hash
+    }
+
+    pub fn skip_contents(&self) -> bool {
+        self.skip_contents
     }
 }
 

--- a/aptlyctl/Cargo.toml
+++ b/aptlyctl/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4", features = ["derive", "env"] }
 color-eyre = "0.6.4"
 http = "1.3.1"
 serde_json = "1.0.140"
+serde_yaml = "0.9"
 tokio = { version = "1.45.1", features = ["full"] }
 tracing = "0.1.41"
 tracing-error = "0.2.1"

--- a/aptlyctl/src/main.rs
+++ b/aptlyctl/src/main.rs
@@ -21,6 +21,7 @@ enum OutputFormat {
     #[default]
     Name,
     Json,
+    Yaml,
 }
 
 #[derive(Subcommand, Debug)]

--- a/aptlyctl/src/publish.rs
+++ b/aptlyctl/src/publish.rs
@@ -1,9 +1,14 @@
-use std::{io::stdout, process::ExitCode};
+use std::{
+    fs,
+    io::{stdin, stdout, Read},
+    path::PathBuf,
+    process::ExitCode,
+};
 
 use aptly_rest::{api::publish, AptlyRest};
 use clap::{Parser, Subcommand, ValueEnum};
 use color_eyre::Result;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::OutputFormat;
 
@@ -88,10 +93,23 @@ pub struct PublishDropOpts {
     ignore_if_missing: bool,
 }
 
+#[derive(Parser, Debug)]
+pub struct PublishImportOpts {
+    /// Path to the file containing publish definitions (reads from stdin if not provided)
+    file: Option<PathBuf>,
+    /// Skip published repositories that already exist
+    #[clap(long)]
+    skip_existing: bool,
+    /// Input format (json or yaml). If not specified, will be inferred from file extension
+    #[clap(long, value_enum)]
+    format: Option<OutputFormat>,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum PublishCommand {
     Create(PublishCreateOpts),
     List(PublishListOpts),
+    Import(PublishImportOpts),
     TestExists(PublishTestExistsOpts),
     Update(PublishUpdateOpts),
     Drop(PublishDropOpts),
@@ -150,6 +168,105 @@ impl PublishCommand {
                         serde_yaml::to_writer(&mut stdout(), &publishes)?;
                     }
                 }
+            }
+            PublishCommand::Import(args) => {
+                let content = if let Some(file) = &args.file {
+                    fs::read(file)?
+                } else {
+                    let mut buffer = Vec::<u8>::new();
+                    stdin().read_to_end(&mut buffer)?;
+                    buffer
+                };
+
+                let publishes: Vec<publish::PublishedRepo> = match args.format {
+                    Some(OutputFormat::Json) => serde_json::from_slice(&content)?,
+                    Some(OutputFormat::Yaml) => serde_yaml::from_slice(&content)?,
+                    Some(OutputFormat::Name) => {
+                        return Err(color_eyre::eyre::eyre!(
+                            "Name format is not supported for import"
+                        ));
+                    }
+                    None => {
+                        // Infer from file extension
+                        if let Some(file) = &args.file {
+                            match file.extension().and_then(|e| e.to_str()) {
+                                Some("yaml" | "yml") => serde_yaml::from_slice(&content)?,
+                                Some("json") => serde_json::from_slice(&content)?,
+                                _ => {
+                                    return Err(color_eyre::eyre::eyre!("Unsupported file format"));
+                                }
+                            }
+                        } else {
+                            // Parse stdin always as JSON
+                            serde_json::from_slice(&content)?
+                        }
+                    }
+                };
+
+                let existing = aptly.published().await?;
+
+                let conflicts: Vec<_> = publishes
+                    .iter()
+                    .filter(|p| {
+                        existing.iter().any(|e| {
+                            e.prefix() == p.prefix() && e.distribution() == p.distribution()
+                        })
+                    })
+                    .collect();
+
+                if !conflicts.is_empty() && !args.skip_existing {
+                    for p in &conflicts {
+                        warn!(
+                            "Published repository '{}/{}' already exists",
+                            p.prefix(),
+                            p.distribution()
+                        );
+                    }
+                    return Err(color_eyre::eyre::eyre!(
+                        "{} published repositories already exist; use --skip-existing to skip them",
+                        conflicts.len()
+                    ));
+                }
+
+                let mut created = 0;
+                let mut skipped = 0;
+
+                for repo in publishes {
+                    if existing.iter().any(|e| {
+                        e.prefix() == repo.prefix() && e.distribution() == repo.distribution()
+                    }) {
+                        info!(
+                            "Published repository '{}/{}' already exists, skipping",
+                            repo.prefix(),
+                            repo.distribution()
+                        );
+                        skipped += 1;
+                    } else {
+                        aptly
+                            .publish_prefix(repo.prefix())
+                            .publish(
+                                repo.source_kind(),
+                                repo.sources(),
+                                &publish::PublishOptions {
+                                    architectures: repo.architectures().to_vec(),
+                                    distribution: Some(repo.distribution().to_owned()),
+                                    label: Some(repo.label().to_owned()),
+                                    origin: Some(repo.origin().to_owned()),
+                                    not_automatic: repo.not_automatic(),
+                                    but_automatic_upgrades: repo.but_automatic_upgrades(),
+                                    acquire_by_hash: repo.acquire_by_hash(),
+                                    skip_contents: repo.skip_contents(),
+                                    ..Default::default()
+                                },
+                            )
+                            .await?;
+                        debug!(?repo);
+                        info!("Created new published repository at '{}'", repo.prefix());
+                        created += 1;
+                    }
+                }
+
+                info!("Import complete: {} created, {} skipped", created, skipped);
             }
             PublishCommand::TestExists(args) => {
                 let publishes = aptly.published().await?;

--- a/aptlyctl/src/publish.rs
+++ b/aptlyctl/src/publish.rs
@@ -146,6 +146,9 @@ impl PublishCommand {
                         serde_json::to_writer_pretty(&mut stdout(), &publishes)?;
                         println!();
                     }
+                    OutputFormat::Yaml => {
+                        serde_yaml::to_writer(&mut stdout(), &publishes)?;
+                    }
                 }
             }
             PublishCommand::TestExists(args) => {

--- a/aptlyctl/src/repo.rs
+++ b/aptlyctl/src/repo.rs
@@ -1,4 +1,9 @@
-use std::{io::stdout, process::ExitCode};
+use std::{
+    fs,
+    io::{stdin, stdout, Read},
+    path::PathBuf,
+    process::ExitCode,
+};
 
 use aptly_rest::{api::repos, key::AptlyKey, AptlyRest, AptlyRestError};
 use clap::{Parser, Subcommand};
@@ -171,10 +176,23 @@ pub struct RepoDropOpts {
     force: bool,
 }
 
+#[derive(Parser, Debug)]
+pub struct RepoImportOpts {
+    /// Path to the file containing repository definitions (reads from stdin if not provided)
+    file: Option<PathBuf>,
+    /// Skip repositories that already exist
+    #[clap(long)]
+    skip_existing: bool,
+    /// Input format (json or yaml). If not specified, will be inferred from file extension
+    #[clap(long, value_enum)]
+    format: Option<OutputFormat>,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum RepoCommand {
     Create(RepoCreateOpts),
     List(RepoListOpts),
+    Import(RepoImportOpts),
     #[clap(subcommand)]
     Packages(RepoPackagesCommand),
     TestExists(RepoTestExistsOpts),
@@ -218,6 +236,79 @@ impl RepoCommand {
                         serde_yaml::to_writer(&mut stdout(), &repos)?;
                     }
                 }
+            }
+
+            RepoCommand::Import(args) => {
+                let content = if let Some(file) = &args.file {
+                    fs::read(file)?
+                } else {
+                    let mut buffer = Vec::<u8>::new();
+                    stdin().read_to_end(&mut buffer)?;
+                    buffer
+                };
+
+                let repos: Vec<repos::Repo> = match args.format {
+                    Some(OutputFormat::Json) => serde_json::from_slice(&content)?,
+                    Some(OutputFormat::Yaml) => serde_yaml::from_slice(&content)?,
+                    Some(OutputFormat::Name) => {
+                        return Err(color_eyre::eyre::eyre!(
+                            "Name format is not supported for import"
+                        ));
+                    }
+                    None => {
+                        // Infer from file extension
+                        if let Some(file) = &args.file {
+                            match file.extension().and_then(|e| e.to_str()) {
+                                Some("yaml" | "yml") => serde_yaml::from_slice(&content)?,
+                                Some("json") => serde_json::from_slice(&content)?,
+                                _ => {
+                                    return Err(color_eyre::eyre::eyre!("Unsupported file format"));
+                                }
+                            }
+                        } else {
+                            // Parse stdin always as JSON
+                            serde_json::from_slice(&content)?
+                        }
+                    }
+                };
+
+                let existing: std::collections::HashSet<_> = aptly
+                    .repos()
+                    .await?
+                    .into_iter()
+                    .map(|r| r.name().to_owned())
+                    .collect();
+
+                let conflicts: Vec<_> = repos
+                    .iter()
+                    .filter(|r| existing.contains(r.name()))
+                    .collect();
+
+                if !conflicts.is_empty() && !args.skip_existing {
+                    for repo in &conflicts {
+                        warn!("Repo '{}' already exists", repo.name());
+                    }
+                    return Err(color_eyre::eyre::eyre!(
+                        "{} repos already exist; use --skip-existing to skip them",
+                        conflicts.len()
+                    ));
+                }
+
+                let mut created = 0;
+                let mut skipped = 0;
+
+                for repo in repos {
+                    if existing.contains(repo.name()) {
+                        info!("Repo '{}' already exists, skipping", repo.name());
+                        skipped += 1;
+                    } else {
+                        aptly.create_repo(&repo).await?;
+                        info!("Created repo '{}'", repo.name());
+                        created += 1;
+                    }
+                }
+
+                info!("Import complete: {} created, {} skipped", created, skipped);
             }
 
             RepoCommand::Packages(command) => return command.run(aptly).await,

--- a/aptlyctl/src/repo.rs
+++ b/aptlyctl/src/repo.rs
@@ -69,6 +69,19 @@ impl RepoPackagesCommand {
 
                     serde_json::to_writer_pretty(&mut stdout(), &results)?;
                 }
+                OutputFormat::Yaml => {
+                    let results = aptly
+                        .repo(&args.repo)
+                        .packages()
+                        .query(args.query, false)
+                        .detailed()
+                        .await?;
+                    if args.fail_if_empty && results.is_empty() {
+                        return Ok(ExitCode::FAILURE);
+                    }
+
+                    serde_yaml::to_writer(&mut stdout(), &results)?;
+                }
             },
             RepoPackagesCommand::Delete(mut args) => {
                 for query in args.queries {
@@ -200,6 +213,9 @@ impl RepoCommand {
                     OutputFormat::Json => {
                         serde_json::to_writer_pretty(&mut stdout(), &repos)?;
                         println!();
+                    }
+                    OutputFormat::Yaml => {
+                        serde_yaml::to_writer(&mut stdout(), &repos)?;
                     }
                 }
             }

--- a/aptlyctl/src/snapshot.rs
+++ b/aptlyctl/src/snapshot.rs
@@ -50,6 +50,9 @@ impl SnapshotCommand {
                         serde_json::to_writer_pretty(&mut stdout(), &snapshots)?;
                         println!();
                     }
+                    OutputFormat::Yaml => {
+                        serde_yaml::to_writer(&mut stdout(), &snapshots)?;
+                    }
                 }
             }
 


### PR DESCRIPTION
Add import functionality to create repositories and publishes from JSON or YAML configuration files or stdin:

    # Import from file
    aptlyctl repo import repos.json
    aptlyctl publish import publishes.yaml

    # Import from stdin
    cat repos.json | aptlyctl repo import

Conflicts are handled as follows:
- Before doing anything, we verify that none of the repos/publishes we are about to create exist; if any do, we abort.
- If --skip-existing is in use, we allow repos/publishes to exist; we don't touch them though.
- We never delete or recreate anything, as this poses a risk of data loss.

Both JSON and YAML are supported as input formats.
If format is unspecified, stdin is always parsed as JSON.
For files, format is selected by the extension.

Some settings (e.g. `--skip-bz2`) cannot be picked up as they’re either not exported by the API `list` uses or not accepted by the object creation API. As far as I know, newer aptly versions improve this situation a bit.

This PR fixes #39.