### PR TITLE
aptlyctl: Add --skip-cleanup

### DIFF
--- a/aptly-rest/src/api/publish.rs
+++ b/aptly-rest/src/api/publish.rs
@@ -277,6 +277,7 @@ pub struct UpdateOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signing: Option<Signing>,
     pub acquire_by_hash: bool,
+    pub skip_cleanup: bool,
     pub skip_contents: bool,
     pub skip_bz2: bool,
 }

--- a/aptlyctl/src/publish.rs
+++ b/aptlyctl/src/publish.rs
@@ -75,6 +75,8 @@ pub struct PublishUpdateOpts {
     #[clap(long)]
     skip_bz2: bool,
     #[clap(long)]
+    skip_cleanup: bool,
+    #[clap(long)]
     skip_contents: bool,
 }
 
@@ -172,6 +174,7 @@ impl PublishCommand {
                     .distribution(&args.distribution)
                     .update(&publish::UpdateOptions {
                         skip_bz2: args.skip_bz2,
+                        skip_cleanup: args.skip_cleanup,
                         skip_contents: args.skip_contents,
                         signing: Some(signing),
                         ..Default::default()


### PR DESCRIPTION
By default, every update of a published repo triggers a repository cleanup, which verifies reference counts and unlinks files no longer referenced anywhere. This process takes a lot of time, and it’s best to decouple it from publishing.

For this, the Aptly API supports a `SkipCleanup` parameter on the publish update endpoint, but it was missing from `UpdateOptions`. Add it to both the API struct and the aptlyctl CLI flag.