### PR TITLE
Add async API calls support

### DIFF
--- a/aptly-rest-mock/Cargo.toml
+++ b/aptly-rest-mock/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 http = "1.3.1"
-serde = "1.0.219"
+serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 url = "2.5.4"
 wiremock = "0.6.3"

--- a/aptly-rest-mock/src/api/db.rs
+++ b/aptly-rest-mock/src/api/db.rs
@@ -1,0 +1,43 @@
+use serde_json::json;
+use wiremock::{Respond, ResponseTemplate};
+
+use crate::AptlyRestMock;
+
+pub(crate) struct DbCleanupResponder {
+    mock: AptlyRestMock,
+}
+
+impl DbCleanupResponder {
+    pub(crate) fn new(mock: AptlyRestMock) -> Self {
+        Self { mock }
+    }
+}
+
+impl Respond for DbCleanupResponder {
+    fn respond(&self, request: &wiremock::Request) -> ResponseTemplate {
+        let mut async_mode = false;
+        for (k, v) in request.url.query_pairs() {
+            if k == "_async" && v == "true" {
+                async_mode = true;
+            }
+        }
+
+        let mut inner = self.mock.inner.write().unwrap();
+        if inner.cleanup_running {
+            return ResponseTemplate::new(409)
+                .set_body_json(json!({"error": "Needed resources are used by other tasks."}));
+        }
+        inner.cleanup_running = true;
+
+        if async_mode {
+            ResponseTemplate::new(202).set_body_json(json!({
+                "ID": 1,
+                "Name": "Clean up db",
+                "State": 0
+            }))
+        } else {
+            inner.cleanup_running = false;
+            ResponseTemplate::new(200).set_body_json(json!({}))
+        }
+    }
+}

--- a/aptly-rest-mock/src/api/mod.rs
+++ b/aptly-rest-mock/src/api/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod db;
 pub(crate) mod packages;
 pub(crate) mod repos;

--- a/aptly-rest-mock/src/lib.rs
+++ b/aptly-rest-mock/src/lib.rs
@@ -25,6 +25,7 @@ pub const APTLY_VERSION: &str = "1.4.0+187+g15f2c97d";
 struct Inner {
     pool: Pool,
     repositories: Repositories,
+    cleanup_running: bool,
 }
 
 #[derive(Clone)]
@@ -38,6 +39,7 @@ impl AptlyRestMock {
         let inner = Arc::new(RwLock::new(Inner {
             pool: Pool::new(),
             repositories: Repositories::new(),
+            cleanup_running: false,
         }));
         let server = AptlyRestMock {
             server: Arc::new(MockServer::start().await),
@@ -68,6 +70,12 @@ impl AptlyRestMock {
         Mock::given(method("GET"))
             .and(path_regex("api/repos/[^/]*/packages"))
             .respond_with(api::repos::ReposPackagesResponder::new(server.clone()))
+            .mount(&server.server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("api/db/cleanup"))
+            .respond_with(api::db::DbCleanupResponder::new(server.clone()))
             .mount(&server.server)
             .await;
 

--- a/aptly-rest/src/api/publish.rs
+++ b/aptly-rest/src/api/publish.rs
@@ -2,7 +2,7 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DeserializeAs, NoneAsEmptyString, SerializeAs};
 
-use crate::AptlyRestError;
+use crate::{AptlyRestError, TaskOr};
 
 #[derive(Debug, Clone)]
 pub struct PublishApi<'a> {
@@ -27,7 +27,7 @@ impl PublishApi<'_> {
         kind: SourceKind,
         sources: &[Source],
         options: &PublishOptions,
-    ) -> Result<PublishedRepo, AptlyRestError> {
+    ) -> Result<TaskOr<PublishedRepo>, AptlyRestError> {
         #[derive(Debug, Serialize)]
         #[serde(rename_all = "PascalCase")]
         struct PublishRequest<'options> {
@@ -64,11 +64,17 @@ impl DistributionApi<'_> {
             .url(&["api", "publish", &self.publish.prefix, &self.distribution])
     }
 
-    pub async fn update(&self, options: &UpdateOptions) -> Result<PublishedRepo, AptlyRestError> {
+    pub async fn update(
+        &self,
+        options: &UpdateOptions,
+    ) -> Result<TaskOr<PublishedRepo>, AptlyRestError> {
         self.publish.aptly.put_body(self.url(), options).await
     }
 
-    pub async fn delete(&self, options: &DeleteOptions) -> Result<(), AptlyRestError> {
+    pub async fn delete(
+        &self,
+        options: &DeleteOptions,
+    ) -> Result<TaskOr<serde_json::Value>, AptlyRestError> {
         let mut url = self.url();
 
         {
@@ -80,9 +86,8 @@ impl DistributionApi<'_> {
 
         self.publish
             .aptly
-            .send_request(self.publish.aptly.client.delete(url))
-            .await?;
-        Ok(())
+            .json_request(self.publish.aptly.client.delete(url))
+            .await
     }
 }
 

--- a/aptly-rest/src/api/repos.rs
+++ b/aptly-rest/src/api/repos.rs
@@ -2,7 +2,7 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr, NoneAsEmptyString};
 
-use crate::{key::AptlyKey, AptlyRestError};
+use crate::{key::AptlyKey, AptlyRestError, TaskOr};
 
 #[derive(Debug, Clone)]
 pub struct RepoApi<'a> {
@@ -29,7 +29,7 @@ impl RepoApi<'_> {
         &self,
         name: &str,
         options: &SnapshotOptions,
-    ) -> Result<crate::Snapshot, AptlyRestError> {
+    ) -> Result<TaskOr<crate::Snapshot>, AptlyRestError> {
         #[derive(Debug, Clone, Serialize)]
         #[serde(rename_all = "PascalCase")]
         struct SnapshotRequest<'a> {
@@ -46,7 +46,10 @@ impl RepoApi<'_> {
             .await
     }
 
-    pub async fn delete(&self, options: &DeleteOptions) -> Result<(), AptlyRestError> {
+    pub async fn delete(
+        &self,
+        options: &DeleteOptions,
+    ) -> Result<TaskOr<serde_json::Value>, AptlyRestError> {
         let mut url = self.aptly.url(&["api", "repos", &self.name]);
 
         {
@@ -56,10 +59,7 @@ impl RepoApi<'_> {
             }
         }
 
-        self.aptly
-            .send_request(self.aptly.client.delete(url))
-            .await?;
-        Ok(())
+        self.aptly.json_request(self.aptly.client.delete(url)).await
     }
 }
 
@@ -128,7 +128,7 @@ impl RepoApiPackages<'_> {
         }
     }
 
-    pub async fn add<'r, R>(&self, keys: R) -> Result<Repo, AptlyRestError>
+    pub async fn add<'r, R>(&self, keys: R) -> Result<TaskOr<Repo>, AptlyRestError>
     where
         R: IntoIterator<Item = &'r AptlyKey>,
     {
@@ -149,7 +149,7 @@ impl RepoApiPackages<'_> {
             .await
     }
 
-    pub async fn delete<'r, R>(&self, keys: R) -> Result<(), AptlyRestError>
+    pub async fn delete<'r, R>(&self, keys: R) -> Result<TaskOr<serde_json::Value>, AptlyRestError>
     where
         R: IntoIterator<Item = &'r AptlyKey>,
     {
@@ -167,9 +167,7 @@ impl RepoApiPackages<'_> {
             .json(&DeleteRequest {
                 package_refs: keys.into_iter().collect(),
             });
-        self.repo.aptly.send_request(req).await?;
-
-        Ok(())
+        self.repo.aptly.json_request(req).await
     }
 }
 
@@ -222,7 +220,7 @@ impl RepoApiFiles<'_> {
         &self,
         directory: &str,
         options: &AddPackageOptions,
-    ) -> Result<AddPackageResponse, AptlyRestError> {
+    ) -> Result<TaskOr<AddPackageResponse>, AptlyRestError> {
         self.repo
             .aptly
             .post(self.url(directory, None, options))
@@ -234,7 +232,7 @@ impl RepoApiFiles<'_> {
         directory: &str,
         filename: &str,
         options: &AddPackageOptions,
-    ) -> Result<AddPackageResponse, AptlyRestError> {
+    ) -> Result<TaskOr<AddPackageResponse>, AptlyRestError> {
         self.repo
             .aptly
             .post(self.url(directory, Some(filename), options))

--- a/aptly-rest/src/api/snapshots.rs
+++ b/aptly-rest/src/api/snapshots.rs
@@ -1,7 +1,7 @@
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
-use crate::AptlyRestError;
+use crate::{AptlyRestError, TaskOr};
 
 #[derive(Debug, Clone)]
 pub struct SnapshotApi<'a> {
@@ -18,7 +18,10 @@ impl SnapshotApi<'_> {
         self.aptly.get(self.url()).await
     }
 
-    pub async fn delete(&self, options: &DeleteOptions) -> Result<(), AptlyRestError> {
+    pub async fn delete(
+        &self,
+        options: &DeleteOptions,
+    ) -> Result<TaskOr<serde_json::Value>, AptlyRestError> {
         let mut url = self.url();
 
         {
@@ -28,10 +31,7 @@ impl SnapshotApi<'_> {
             }
         }
 
-        self.aptly
-            .send_request(self.aptly.client.delete(url))
-            .await?;
-        Ok(())
+        self.aptly.json_request(self.aptly.client.delete(url)).await
     }
 }
 

--- a/aptly-rest/src/lib.rs
+++ b/aptly-rest/src/lib.rs
@@ -22,12 +22,40 @@ pub enum AptlyRestError {
     Request(#[from] reqwest::Error),
     #[error("Invalid authentication token {0}")]
     InvalidAuthToken(#[from] header::InvalidHeaderValue),
+    #[error("{status}: {message}")]
+    AptlyError {
+        status: reqwest::StatusCode,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Task {
+    #[serde(rename = "ID")]
+    pub id: i64,
+    pub name: String,
+    pub state: i32,
+}
+
+impl std::fmt::Display for Task {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Task Id: {} ({})", self.id, self.name)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum TaskOr<T> {
+    Task(Task),
+    Value(T),
 }
 
 #[derive(Debug, Clone)]
 pub struct AptlyRest {
     client: reqwest::Client,
     url: Url,
+    pub async_mode: bool,
 }
 
 impl AptlyRest {
@@ -35,6 +63,7 @@ impl AptlyRest {
         Self {
             client: reqwest::Client::new(),
             url,
+            async_mode: false,
         }
     }
 
@@ -47,6 +76,7 @@ impl AptlyRest {
                 .default_headers(headers)
                 .build()?,
             url,
+            async_mode: false,
         })
     }
 
@@ -65,10 +95,9 @@ impl AptlyRest {
         Ok(v.version)
     }
 
-    pub async fn db_cleanup(&self) -> Result<(), AptlyRestError> {
+    pub async fn db_cleanup(&self) -> Result<TaskOr<serde_json::Value>, AptlyRestError> {
         let url = self.url(&["api", "db", "cleanup"]);
-        self.post::<()>(url).await?;
-        Ok(())
+        self.post(url).await
     }
 
     pub async fn repos(&self) -> Result<Vec<Repo>, AptlyRestError> {
@@ -170,7 +199,25 @@ impl AptlyRest {
         &self,
         req: reqwest::RequestBuilder,
     ) -> Result<reqwest::Response, AptlyRestError> {
-        Ok(req.send().await?.error_for_status()?)
+        let req = if self.async_mode {
+            req.query(&[("_async", "true")])
+        } else {
+            req
+        };
+        let response = req.send().await?;
+        if self.async_mode && response.status() == reqwest::StatusCode::CONFLICT {
+            let message = response
+                .json::<serde_json::Value>()
+                .await
+                .ok()
+                .and_then(|v| v["error"].as_str().map(String::from))
+                .unwrap_or_else(|| "Conflict".to_string());
+            return Err(AptlyRestError::AptlyError {
+                status: reqwest::StatusCode::CONFLICT,
+                message,
+            });
+        }
+        Ok(response.error_for_status()?)
     }
 
     async fn json_request<T>(&self, req: reqwest::RequestBuilder) -> Result<T, AptlyRestError>

--- a/aptly-rest/tests/async_and_errors.rs
+++ b/aptly-rest/tests/async_and_errors.rs
@@ -1,0 +1,47 @@
+use aptly_rest::{AptlyRest, AptlyRestError, TaskOr};
+use aptly_rest_mock::AptlyRestMock;
+
+#[tokio::test]
+async fn db_cleanup_sync() {
+    let mock = AptlyRestMock::start().await;
+    let aptly = AptlyRest::new(mock.url());
+
+    let result = aptly.db_cleanup().await.unwrap();
+    assert!(matches!(result, TaskOr::Value(_)));
+}
+
+#[tokio::test]
+async fn db_cleanup_async() {
+    let mock = AptlyRestMock::start().await;
+    let mut aptly = AptlyRest::new(mock.url());
+    aptly.async_mode = true;
+
+    let result = aptly.db_cleanup().await.unwrap();
+    match result {
+        TaskOr::Task(task) => {
+            assert_eq!(task.name, "Clean up db");
+        }
+        TaskOr::Value(value) => panic!("Expected Task, got {:?}", value),
+    }
+}
+
+#[tokio::test]
+async fn db_cleanup_conflict() {
+    let mock = AptlyRestMock::start().await;
+    let mut aptly = AptlyRest::new(mock.url());
+    aptly.async_mode = true;
+
+    // First call succeeds with a task
+    let result = aptly.db_cleanup().await.unwrap();
+    assert!(matches!(result, TaskOr::Task(_)));
+
+    // Second call hits 409 because the first is still running
+    let err = aptly.db_cleanup().await.unwrap_err();
+    match err {
+        AptlyRestError::AptlyError { status, message } => {
+            assert_eq!(status, 409);
+            assert_eq!(message, "Needed resources are used by other tasks.");
+        }
+        other => panic!("Expected AptlyError, got {:?}", other),
+    }
+}

--- a/aptlyctl/src/main.rs
+++ b/aptlyctl/src/main.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 
-use aptly_rest::AptlyRest;
+use aptly_rest::{AptlyRest, TaskOr};
 use clap::{Parser, Subcommand, ValueEnum};
 use color_eyre::Result;
 use publish::PublishCommand;
@@ -59,6 +59,9 @@ struct Opts {
     /// Authentication token for the API
     #[clap(long, env = "APTLY_API_TOKEN")]
     api_token: Option<String>,
+    /// Run the operation asynchronously on the server
+    #[clap(long = "async")]
+    async_mode: bool,
 }
 
 #[tokio::main]
@@ -69,11 +72,12 @@ async fn main() -> Result<ExitCode> {
         .init();
     color_eyre::install().unwrap();
     let opts = Opts::parse();
-    let aptly = if let Some(token) = opts.api_token {
+    let mut aptly = if let Some(token) = opts.api_token {
         AptlyRest::new_with_token(opts.api_url, &token)?
     } else {
         AptlyRest::new(opts.api_url)
     };
+    aptly.async_mode = opts.async_mode;
 
     match opts.command {
         Command::Repo { command } => command.run(&aptly).await,
@@ -81,8 +85,15 @@ async fn main() -> Result<ExitCode> {
         Command::Snapshot { command } => command.run(&aptly).await,
         Command::Tools { command } => command.run().await,
         Command::DbCleanup => {
-            aptly.db_cleanup().await?;
-            info!("Ran database cleanup");
+            let result = aptly.db_cleanup().await?;
+            match result {
+                TaskOr::Value(_) => {
+                    info!("Ran database cleanup");
+                }
+                TaskOr::Task(task) => {
+                    info!("{task}");
+                }
+            }
             Ok(ExitCode::SUCCESS)
         }
     }

--- a/aptlyctl/src/publish.rs
+++ b/aptlyctl/src/publish.rs
@@ -1,6 +1,6 @@
 use std::{io::stdout, process::ExitCode};
 
-use aptly_rest::{api::publish, AptlyRest};
+use aptly_rest::{api::publish, AptlyRest, TaskOr};
 use clap::{Parser, Subcommand, ValueEnum};
 use color_eyre::Result;
 use tracing::{debug, info};
@@ -110,7 +110,7 @@ impl PublishCommand {
                     publish::Signing::Disabled
                 };
 
-                let repo = aptly
+                let result = aptly
                     .publish_prefix(&args.prefix)
                     .publish(
                         args.kind.into(),
@@ -125,8 +125,15 @@ impl PublishCommand {
                         },
                     )
                     .await?;
-                debug!(?repo);
-                info!("Created new published repository at '{}'", repo.prefix());
+                match result {
+                    TaskOr::Value(repo) => {
+                        debug!(?repo);
+                        info!("Created new published repository at '{}'", repo.prefix());
+                    }
+                    TaskOr::Task(task) => {
+                        info!("{task}");
+                    }
+                }
             }
             PublishCommand::List(args) => {
                 let publishes = aptly.published().await?;
@@ -167,7 +174,7 @@ impl PublishCommand {
                     publish::Signing::Disabled
                 };
 
-                let repo = aptly
+                let result = aptly
                     .publish_prefix(&args.prefix)
                     .distribution(&args.distribution)
                     .update(&publish::UpdateOptions {
@@ -177,12 +184,19 @@ impl PublishCommand {
                         ..Default::default()
                     })
                     .await?;
-                debug!(?repo);
-                info!(
-                    "Updated published repository at '{}/{}'",
-                    repo.prefix(),
-                    repo.distribution()
-                );
+                match result {
+                    TaskOr::Value(repo) => {
+                        debug!(?repo);
+                        info!(
+                            "Updated published repository at '{}/{}'",
+                            repo.prefix(),
+                            repo.distribution()
+                        );
+                    }
+                    TaskOr::Task(task) => {
+                        info!("{task}");
+                    }
+                }
             }
             PublishCommand::Drop(args) => {
                 if args.ignore_if_missing
@@ -194,15 +208,22 @@ impl PublishCommand {
                 {
                     info!("Not published; doing nothing.");
                 } else {
-                    aptly
+                    let result = aptly
                         .publish_prefix(&args.prefix)
                         .distribution(&args.distribution)
                         .delete(&publish::DeleteOptions { force: args.force })
                         .await?;
-                    info!(
-                        "Deleted published repository at '{}/{}'",
-                        args.prefix, args.distribution
-                    );
+                    match result {
+                        TaskOr::Value(_) => {
+                            info!(
+                                "Deleted published repository at '{}/{}'",
+                                args.prefix, args.distribution
+                            );
+                        }
+                        TaskOr::Task(task) => {
+                            info!("{task}");
+                        }
+                    }
                 }
             }
         }

--- a/aptlyctl/src/repo.rs
+++ b/aptlyctl/src/repo.rs
@@ -1,6 +1,6 @@
 use std::{io::stdout, process::ExitCode};
 
-use aptly_rest::{api::repos, key::AptlyKey, AptlyRest, AptlyRestError};
+use aptly_rest::{api::repos, key::AptlyKey, AptlyRest, AptlyRestError, TaskOr};
 use clap::{Parser, Subcommand};
 use color_eyre::Result;
 use http::StatusCode;
@@ -96,12 +96,19 @@ impl RepoPackagesCommand {
                 } else {
                     info!("Deleting {} package(s)...", args.keys.len());
 
-                    aptly
+                    let result = aptly
                         .repo(&args.repo)
                         .packages()
                         .delete(args.keys.iter())
                         .await?;
-                    info!("Deletion complete");
+                    match result {
+                        TaskOr::Value(_) => {
+                            info!("Deletion complete");
+                        }
+                        TaskOr::Task(task) => {
+                            info!("{task}");
+                        }
+                    }
                 }
             }
         }
@@ -219,28 +226,33 @@ impl RepoCommand {
                 .await;
             }
 
-            RepoCommand::TestExists(args) => {
-                if let Err(err) = aptly.repo(&args.repo).get().await {
-                    if let AptlyRestError::Request(err) = &err {
-                        if err.status() == Some(StatusCode::NOT_FOUND) {
-                            return Ok(ExitCode::FAILURE);
-                        }
-                    }
-
-                    return Err(err.into());
+            RepoCommand::TestExists(args) => match aptly.repo(&args.repo).get().await {
+                Ok(_) => {}
+                Err(AptlyRestError::Request(ref e))
+                    if e.status() == Some(StatusCode::NOT_FOUND) =>
+                {
+                    return Ok(ExitCode::FAILURE);
                 }
-            }
+                Err(err) => return Err(err.into()),
+            },
 
             RepoCommand::Snapshot(args) => {
-                let snapshot = aptly
+                let result = aptly
                     .repo(&args.repo)
                     .snapshot(&args.snapshot, &Default::default())
                     .await?;
-                info!(
-                    "Created snapshot '{}' of repo '{}'",
-                    snapshot.name(),
-                    args.repo
-                );
+                match result {
+                    TaskOr::Value(snapshot) => {
+                        info!(
+                            "Created snapshot '{}' of repo '{}'",
+                            snapshot.name(),
+                            args.repo
+                        );
+                    }
+                    TaskOr::Task(task) => {
+                        info!("{task}");
+                    }
+                }
             }
 
             RepoCommand::Clean(args) => {
@@ -258,11 +270,18 @@ impl RepoCommand {
             }
 
             RepoCommand::Drop(args) => {
-                aptly
+                let result = aptly
                     .repo(&args.repo)
                     .delete(&repos::DeleteOptions { force: args.force })
                     .await?;
-                info!("Deleted repo '{}'", args.repo);
+                match result {
+                    TaskOr::Value(_) => {
+                        info!("Deleted repo '{}'", args.repo);
+                    }
+                    TaskOr::Task(task) => {
+                        info!("{task}");
+                    }
+                }
             }
         }
 

--- a/aptlyctl/src/snapshot.rs
+++ b/aptlyctl/src/snapshot.rs
@@ -68,7 +68,7 @@ impl SnapshotCommand {
             SnapshotCommand::Drop(args) => {
                 aptly
                     .snapshot(&args.snapshot)
-                    .delete(&Default::default())
+                    .delete(&aptly_rest::api::snapshots::DeleteOptions { force: args.force })
                     .await?;
                 info!("Deleted snapshot '{}'", args.snapshot);
             }

--- a/aptlyctl/src/snapshot.rs
+++ b/aptlyctl/src/snapshot.rs
@@ -1,6 +1,6 @@
 use std::{io::stdout, process::ExitCode};
 
-use aptly_rest::{AptlyRest, AptlyRestError};
+use aptly_rest::{AptlyRest, AptlyRestError, TaskOr};
 use clap::{Parser, Subcommand};
 use color_eyre::Result;
 use http::StatusCode;
@@ -53,24 +53,29 @@ impl SnapshotCommand {
                 }
             }
 
-            SnapshotCommand::TestExists(args) => {
-                if let Err(err) = aptly.snapshot(&args.snapshot).get().await {
-                    if let AptlyRestError::Request(err) = &err {
-                        if err.status() == Some(StatusCode::NOT_FOUND) {
-                            return Ok(ExitCode::FAILURE);
-                        }
-                    }
-
-                    return Err(err.into());
+            SnapshotCommand::TestExists(args) => match aptly.snapshot(&args.snapshot).get().await {
+                Ok(_) => {}
+                Err(AptlyRestError::Request(ref e))
+                    if e.status() == Some(StatusCode::NOT_FOUND) =>
+                {
+                    return Ok(ExitCode::FAILURE);
                 }
-            }
+                Err(err) => return Err(err.into()),
+            },
 
             SnapshotCommand::Drop(args) => {
-                aptly
+                let result = aptly
                     .snapshot(&args.snapshot)
                     .delete(&aptly_rest::api::snapshots::DeleteOptions { force: args.force })
                     .await?;
-                info!("Deleted snapshot '{}'", args.snapshot);
+                match result {
+                    TaskOr::Value(_) => {
+                        info!("Deleted snapshot '{}'", args.snapshot);
+                    }
+                    TaskOr::Task(task) => {
+                        info!("{task}");
+                    }
+                }
             }
         }
 

--- a/sync2aptly/src/lib.rs
+++ b/sync2aptly/src/lib.rs
@@ -27,7 +27,7 @@ use aptly_rest::{
     api::{files::UploadFiles, packages},
     dsc::DscFile,
     key::AptlyKey,
-    AptlyRest, AptlyRestError,
+    AptlyRest, AptlyRestError, TaskOr,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -1149,12 +1149,15 @@ impl SyncActions {
                 uploaded_packages
             );
 
-            let response = self
+            let result = self
                 .aptly
                 .repo(&self.repo)
                 .files()
                 .add_directory(upload_dir, &Default::default())
                 .await?;
+            let TaskOr::Value(response) = result else {
+                bail!("Unexpected async response");
+            };
             debug!(?response);
 
             let warnings = response.report().warnings();


### PR DESCRIPTION
The Aptly API can run operations asynchronously when called with ?_async=true, returning a task description and identifier instead of the usual response.

This mode allows, for example, triggering repository cleanup (which normally happens during 'publish update') in the background without waiting for it to complete.

Since the async operation is supported by a large number of methods, this is implemented as a separate global mode triggered by --async.

API calls that support async at the time of writing:

 - `POST /api/repos/{name}/snapshots`
 - `DELETE /api/repos/{name}`
 - `POST /api/repos/{name}/packages`
 - `DELETE /api/repos/{name}/packages`
 - `POST /api/repos/{name}/file/{dir}`
 - `POST /api/repos/{name}/file/{dir}/{file}`
 - `POST /api/publish/{prefix}`
 - `PUT /api/publish/{prefix}/{distribution}`
 - `DELETE /api/publish/{prefix}/{distribution}`
 - `DELETE /api/snapshots/{name}`
 - `POST /api/db/cleanup`